### PR TITLE
[ALFREDOPS-855]: added 's01' prefixes to sonatype publish urls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ allprojects {
     repositories {
         maven {
             name 'Maven Central Snapshots'
-            url 'https://oss.sonatype.org/content/repositories/snapshots/'
+            url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
         }
     }
 }

--- a/publish.gradle
+++ b/publish.gradle
@@ -36,8 +36,8 @@ publishing {
         // Sonatype
         maven {
             name = 'Sonatype'
-            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+            def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+            def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
             url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 
             credentials {


### PR DESCRIPTION
https://xenitsupport.jira.com/browse/ALFREDOPS-855

Exception thrown by GitHub CI/CD while trying to publish SNAPSHOT for Care4Alf 4.0.0:

 

Could not PUT 'https://oss.sonatype.org/content/repositories/snapshots/eu/xenit/care4alf/care4alf-6x/4.0.0-SNAPSHOT/maven-metadata.xml'. Received status code 403 from server: Forbidden

 

 

This ticket serves as a bug fix for this problem.